### PR TITLE
fix: i18n keys and updated list

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -199,7 +199,7 @@ commento = false
   paypal = ""
   patreon = ""
 
-# possible share name: ["facebook","twitter", "reddit", "linkedin", "tumblr", "weibo", "douban", "line", "pocket", "feedly", "hatena", "pinterest"]
+# possible share name: ["facebook", "twitter", "reddit", "linkedin", "tumblr", "weibo", "douban", "line", "telegram", "whatsapp", "pocket", "feedly", "hatena", "pinterest"]
 [[share]]
   name = "facebook"
   username = ""

--- a/layouts/partials/body/share.html
+++ b/layouts/partials/body/share.html
@@ -40,27 +40,27 @@
           {{ partial "svgs/share/line.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ else if eq (lower .name) "telegram" }}
-        <a href='https://telegram.me/share/url?url=' onclick='window.open(&apos;https://telegram.me/share/url?url=&apos;+encodeURIComponent(location.href)+&apos;&amp;bodytext=&amp;tags=&amp;text=&apos;+encodeURIComponent(document.title));return false;' class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "line" | default "Telegram" }}" aria-label="Telegram Share Button" data-type="share">
+        <a href='https://telegram.me/share/url?url=' onclick='window.open(&apos;https://telegram.me/share/url?url=&apos;+encodeURIComponent(location.href)+&apos;&amp;bodytext=&amp;tags=&amp;text=&apos;+encodeURIComponent(document.title));return false;' class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "telegram" | default "Telegram" }}" aria-label="Telegram Share Button" data-type="share">
           {{ partial "svgs/social/telegram.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ else if eq (lower .name) "whatsapp" }}
-        <a href="https://web.whatsapp.com/send?text={{ $ctx.Title }} - {{ $ctx.Permalink | absLangURL }}" data-href="{{ $ctx.Permalink | absLangURL }}" class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "line" | default "WhatsApp" }}" aria-label="WhatsApp Share Button" data-type="share">
+        <a href="https://web.whatsapp.com/send?text={{ $ctx.Title }} - {{ $ctx.Permalink | absLangURL }}" data-href="{{ $ctx.Permalink | absLangURL }}" class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "whatsapp" | default "WhatsApp" }}" aria-label="WhatsApp Share Button" data-type="share">
           {{ partial "svgs/social/whatsapp.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ else if eq (lower .name) "pocket" }}
-        <a href="https://getpocket.com/save?url={{ $ctx.Permalink | absLangURL }}" class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "line" | default "Pocket" }}" aria-label="Pocket Share Button" data-type="share">
+        <a href="https://getpocket.com/save?url={{ $ctx.Permalink | absLangURL }}" class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "pocket" | default "Pocket" }}" aria-label="Pocket Share Button" data-type="share">
           {{ partial "svgs/share/pocket.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ else if eq (lower .name) "feedly" }}
-        <a href="https://feedly.com/i/subscription/feed/{{ .Permalink | absLangURL }}index.xml" class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "line" | default "Feedly" }}" aria-label="Feedly Share Button" data-type="share">
+        <a href="https://feedly.com/i/subscription/feed/{{ .Permalink | absLangURL }}index.xml" class="donation__item" target="_blank" rel="noreferrer" title="{{ i18n "feedly" | default "Feedly" }}" aria-label="Feedly Share Button" data-type="share">
           {{ partial "svgs/share/feedly.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ else if eq (lower .name) "hatena" }}
-        <a href="https://b.hatena.ne.jp/entry/panel/?btitle={{ $ctx.Title }}&url={{ $ctx.Permalink | absLangURL }}" title="{{ i18n "Hatena Blog" | default "Hatena Blog" }}" aria-label="Hatena Blog Share Button" class="donation__item" target="_blank" rel="noreferrer" data-type="share">
+        <a href="https://b.hatena.ne.jp/entry/panel/?btitle={{ $ctx.Title }}&url={{ $ctx.Permalink | absLangURL }}" title="{{ i18n "hatena" | default "Hatena Blog" }}" aria-label="Hatena Blog Share Button" class="donation__item" target="_blank" rel="noreferrer" data-type="share">
           {{ partial "svgs/share/hatena.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ else if eq (lower .name) "pinterest" }}
-        <a href="http://www.pinterest.com/pin/create/button/?url={{ $ctx.Permalink | absLangURL }}{{ if $.Param "featured_image" }}&media={{ (print "images/" ($.Param "featured_image")) | absURL }}{{ else if $.Param "image" }}&media={{ $.Param "image" | absURL }}{{end}}&description={{ $ctx.Description }}" title="{{ i18n "Pinterest" | default "Pinterest" }}" aria-label="Pinterest Share Button" class="donation__item" target="_blank" rel="noreferrer" data-type="share">
+        <a href="http://www.pinterest.com/pin/create/button/?url={{ $ctx.Permalink | absLangURL }}{{ if $.Param "featured_image" }}&media={{ (print "images/" ($.Param "featured_image")) | absURL }}{{ else if $.Param "image" }}&media={{ $.Param "image" | absURL }}{{end}}&description={{ $ctx.Description }}" title="{{ i18n "pinterest" | default "Pinterest" }}" aria-label="Pinterest Share Button" class="donation__item" target="_blank" rel="noreferrer" data-type="share">
           {{ partial "svgs/share/pinterest.svg" (dict "width" 35 "height" 35) }}
         </a>
       {{ end }}


### PR DESCRIPTION
* Fixed i18n keys for affected services (originally left as "line")
* Also lowercased i18n key "pinterest" (translation keys are case-sensitive)
* Added "telegram" and "whatsapp" in the list of services in the sample config file.
