### PR TITLE
fix: breadcrumb not turning-off when in term list

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -2,7 +2,9 @@
 
 <main class="main inner" data-sidebar-position="{{ $.Param "sidebarPosition" }}">
   <div class="list__main {{ if $.Param "enableSidebar" }}{{ if eq ($.Param "sidebarPosition") "left" }}mr{{ else }}lm{{ end }}{{ else }}lmr{{ end }}">
-    {{ partial "body/breadcrumb" . }}
+    {{ if $.Param "enableBreadcrumb" }}
+      {{ partial "body/breadcrumb" . }}
+    {{ end }}
     <header class="list__header">
       <h5 class="list__header--title capitalize h5">{{ .Title }}</h5>
     </header>


### PR DESCRIPTION
When breadcrumb is turned-off in config file, it remains available in `/categories/{term}/` and `/tags/{term}/ ` list view.